### PR TITLE
update @vivliostyle/cli and ws for security

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@vivliostyle/cli": "^8.9.1",
+        "@vivliostyle/cli": "^8.14.1",
         "npm-run-all2": "^6.0.0",
         "textlint": "^14.0.0",
         "textlint-filter-rule-comments": "^1.2.2",
@@ -1577,24 +1577,23 @@
       "license": "ISC"
     },
     "node_modules/@vivliostyle/cli": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/@vivliostyle/cli/-/cli-8.12.0.tgz",
-      "integrity": "sha512-KnLz/NyfiWaRQaDDyOlqPjcMeBYtG+rI+usDUFiPcxV1S7XwooBIE5dE3xGbcu6Koq3Ju6/sgG1tYauq/WRBXA==",
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/@vivliostyle/cli/-/cli-8.14.1.tgz",
+      "integrity": "sha512-XsJLfwEPMvQT+E1lJX+ZDJB3yremFThYv+v/JPp5RGDx6/M33gX/E+TmVH+klofVvEXcRGJYPUwiYIkTvBUG6g==",
       "dev": true,
-      "license": "AGPL-3.0",
       "dependencies": {
         "@napi-rs/canvas": "0.1.41",
         "@npmcli/arborist": "^6.1.3",
         "@vivliostyle/jsdom": "22.1.0-vivliostyle-cli.1",
         "@vivliostyle/vfm": "2.2.1",
-        "@vivliostyle/viewer": "2.30.0",
+        "@vivliostyle/viewer": "2.30.4",
         "ajv": "^8.11.2",
         "ajv-formats": "^2.1.1",
         "archiver": "^5.3.1",
         "bcp-47-match": "^2.0.3",
         "better-ajv-errors": "^1.2.0",
         "chalk": "^4.1.2",
-        "cheerio": "^1.0.0-rc.10",
+        "cheerio": "^1.0.0",
         "chokidar": "^3.5.2",
         "command-exists": "1.2.9",
         "commander": "^9.4.1",
@@ -1614,7 +1613,7 @@
         "node-stream-zip": "^1.14.0",
         "ora": "^5.4.1",
         "pdf-lib": "^1.16.0",
-        "playwright-core": "1.44.1",
+        "playwright-core": "1.46.1",
         "portfinder": "^1.0.28",
         "press-ready": "^4.0.3",
         "prettier": "^2.3.2",
@@ -2136,11 +2135,10 @@
       }
     },
     "node_modules/@vivliostyle/core": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@vivliostyle/core/-/core-2.30.0.tgz",
-      "integrity": "sha512-DDpsH0lmNRSow4Hq3aBlW46cC0K9pPTK00YYzgfin+dEg4uVY0jpt1V1Ne5+yim49U5kyrCLCs+s6LxrPx6Vyg==",
+      "version": "2.30.4",
+      "resolved": "https://registry.npmjs.org/@vivliostyle/core/-/core-2.30.4.tgz",
+      "integrity": "sha512-f2+k3KtzZnR60EKbhveOQYkmN8CdKhoyUIDcnxmwA/qptrGkq0ycPlcSRd9WeEo5y4tvDa66+x/AeHjw5PD0dQ==",
       "dev": true,
-      "license": "AGPL-3.0",
       "dependencies": {
         "fast-diff": "^1.2.0"
       },
@@ -2336,13 +2334,12 @@
       }
     },
     "node_modules/@vivliostyle/viewer": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@vivliostyle/viewer/-/viewer-2.30.0.tgz",
-      "integrity": "sha512-SC3fHogmGcOAqpAiCvr6YI2UwTz7jDmRcKWym0tt4tSg01pf259/uzj4FWm6Uw/0HQnVjBDT3CRHc5stxSM/fg==",
+      "version": "2.30.4",
+      "resolved": "https://registry.npmjs.org/@vivliostyle/viewer/-/viewer-2.30.4.tgz",
+      "integrity": "sha512-1UXtsA4fvpDTpw6+eXhA6SMZx0J0W7UCgnwlGHeCHzqVW1Bf2U366+Y++hRjfwIuXc3EiSGtoWU269np3L24gg==",
       "dev": true,
-      "license": "AGPL-3.0",
       "dependencies": {
-        "@vivliostyle/core": "^2.30.0",
+        "@vivliostyle/core": "^2.30.4",
         "i18next-ko": "^3.0.1",
         "knockout": "^3.5.0"
       },
@@ -3124,21 +3121,25 @@
       "dev": true
     },
     "node_modules/cheerio": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
-      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
+      "integrity": "sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==",
       "dev": true,
       "dependencies": {
         "cheerio-select": "^2.1.0",
         "dom-serializer": "^2.0.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "htmlparser2": "^8.0.1",
-        "parse5": "^7.0.0",
-        "parse5-htmlparser2-tree-adapter": "^7.0.0"
+        "domutils": "^3.1.0",
+        "encoding-sniffer": "^0.2.0",
+        "htmlparser2": "^9.1.0",
+        "parse5": "^7.1.2",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^6.19.5",
+        "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=18.17"
       },
       "funding": {
         "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
@@ -3171,6 +3172,15 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chokidar": {
@@ -3900,6 +3910,31 @@
         "iconv-lite": "^0.6.2"
       }
     },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.0.tgz",
+      "integrity": "sha512-ju7Wq1kg04I3HtiYIOrUrdfdDvkyO9s5XM8QAj/bN61Yo/Vb4vgJxy5vi4Yxk01gWHbrofpPtpxM8bKger9jhg==",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -4061,8 +4096,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-      "dev": true,
-      "license": "Apache-2.0"
+      "dev": true
     },
     "node_modules/fast-equals": {
       "version": "4.0.3",
@@ -4889,9 +4923,9 @@
       }
     },
     "node_modules/htmlparser2": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
       "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
@@ -4903,8 +4937,8 @@
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "entities": "^4.4.0"
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -4962,15 +4996,13 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/i18next/-/i18next-3.5.2.tgz",
       "integrity": "sha512-42eGG1b56O5NR01Gudod1R3LzPugN6tZ3ZmYtAqOJSmx4V3vD07hLtkkFrv/qu1mRecW1woezyXFZBFnNAgRXw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/i18next-ko": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/i18next-ko/-/i18next-ko-3.0.1.tgz",
       "integrity": "sha512-Z0HMTiJHU1zP+Lgp8H8iZYmOZHrUVu6LaAWAmm5cMuP4y/VFAghEfs9kDuQ86+S+g45TCKzX76MqyNGemlJuMA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "i18next": "^3.4.3"
       }
@@ -5568,8 +5600,7 @@
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/knockout/-/knockout-3.5.1.tgz",
       "integrity": "sha512-wRJ9I4az0QcsH7A4v4l0enUpkS++MBx0BnL/68KaLzJg7x1qmbjSlwEoCNol7KTYZ+pmtI7Eh2J0Nu6/2Z5J/Q==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/kuromoji": {
       "version": "0.1.2",
@@ -7978,6 +8009,30 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dev": true,
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream/node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -8141,16 +8196,15 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.44.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.1.tgz",
-      "integrity": "sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==",
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.46.1.tgz",
+      "integrity": "sha512-h9LqIQaAv+CYvWzsZ+h3RsrqCStkBHlgo6/TJlFst3cOTlLghBQlJwPOZKQJTKNaD3QIB7aAVQ+gfWbN3NXB7A==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/pluralize": {
@@ -10969,6 +11023,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.8.tgz",
+      "integrity": "sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "clean": "rm -rf ./book/output/"
   },
   "devDependencies": {
-    "@vivliostyle/cli": "^8.9.1",
+    "@vivliostyle/cli": "^8.14.1",
     "npm-run-all2": "^6.0.0",
     "textlint": "^14.0.0",
     "textlint-filter-rule-comments": "^1.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,13 +81,13 @@ __metadata:
   linkType: hard
 
 "@babel/types@npm:^7.8.3":
-  version: 7.25.4
-  resolution: "@babel/types@npm:7.25.4"
+  version: 7.25.6
+  resolution: "@babel/types@npm:7.25.6"
   dependencies:
     "@babel/helper-string-parser": "npm:^7.24.8"
     "@babel/helper-validator-identifier": "npm:^7.24.7"
     to-fast-properties: "npm:^2.0.0"
-  checksum: 10c0/9aa25dfcd89cc4e4dde3188091c34398a005a49e2c2b069d0367b41e1122c91e80fd92998c52a90f2fb500f7e897b6090ec8be263d9cb53d0d75c756f44419f2
+  checksum: 10c0/89d45fbee24e27a05dca2d08300a26b905bd384a480448823f6723c72d3a30327c517476389b7280ce8cb9a2c48ef8f47da7f9f6d326faf6f53fd6b68237bdc4
   languageName: node
   linkType: hard
 
@@ -1048,22 +1048,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vivliostyle/cli@npm:^8.9.1":
-  version: 8.12.0
-  resolution: "@vivliostyle/cli@npm:8.12.0"
+"@vivliostyle/cli@npm:^8.14.1":
+  version: 8.14.1
+  resolution: "@vivliostyle/cli@npm:8.14.1"
   dependencies:
     "@napi-rs/canvas": "npm:0.1.41"
     "@npmcli/arborist": "npm:^6.1.3"
     "@vivliostyle/jsdom": "npm:22.1.0-vivliostyle-cli.1"
     "@vivliostyle/vfm": "npm:2.2.1"
-    "@vivliostyle/viewer": "npm:2.30.0"
+    "@vivliostyle/viewer": "npm:2.30.4"
     ajv: "npm:^8.11.2"
     ajv-formats: "npm:^2.1.1"
     archiver: "npm:^5.3.1"
     bcp-47-match: "npm:^2.0.3"
     better-ajv-errors: "npm:^1.2.0"
     chalk: "npm:^4.1.2"
-    cheerio: "npm:^1.0.0-rc.10"
+    cheerio: "npm:^1.0.0"
     chokidar: "npm:^3.5.2"
     command-exists: "npm:1.2.9"
     commander: "npm:^9.4.1"
@@ -1083,7 +1083,7 @@ __metadata:
     node-stream-zip: "npm:^1.14.0"
     ora: "npm:^5.4.1"
     pdf-lib: "npm:^1.16.0"
-    playwright-core: "npm:1.44.1"
+    playwright-core: "npm:1.46.1"
     portfinder: "npm:^1.0.28"
     press-ready: "npm:^4.0.3"
     prettier: "npm:^2.3.2"
@@ -1099,16 +1099,16 @@ __metadata:
   bin:
     vivliostyle: dist/cli.js
     vs: dist/cli.js
-  checksum: 10c0/593d1ce92c65cdc276c2ae1c21723acf7ec018a6feb9ef947b85d4d7913230798fd06052b2a39c12a28ba457fdc4546a9805d003e212adfca1c6000345bfe71c
+  checksum: 10c0/59dc9838fbf7831c6538b2002a4c45339bb078dde59ab117bd35f430304642a35e936af6b3aea3c10101a57eb51a13ee55aba4fd137889d525b1c840122d7230
   languageName: node
   linkType: hard
 
-"@vivliostyle/core@npm:^2.30.0":
-  version: 2.30.0
-  resolution: "@vivliostyle/core@npm:2.30.0"
+"@vivliostyle/core@npm:^2.30.4":
+  version: 2.30.4
+  resolution: "@vivliostyle/core@npm:2.30.4"
   dependencies:
     fast-diff: "npm:^1.2.0"
-  checksum: 10c0/5a676ba7f480d6494de1b91fa902d08f7819957e4aac067375fca6ca559571a163f5c084326ade194fe3e628fff380d6d5974bffdd3bba363cde8a2e3a2ae968
+  checksum: 10c0/622cf88f5fe467d1ea5e6a11a7d11835f1bda81f888954cfe16777c017049488ed6d96247634e3dd0c94b89a3944d3c10bd09db37efbea5d027f2d8f46f143d5
   languageName: node
   linkType: hard
 
@@ -1191,14 +1191,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vivliostyle/viewer@npm:2.30.0":
-  version: 2.30.0
-  resolution: "@vivliostyle/viewer@npm:2.30.0"
+"@vivliostyle/viewer@npm:2.30.4":
+  version: 2.30.4
+  resolution: "@vivliostyle/viewer@npm:2.30.4"
   dependencies:
-    "@vivliostyle/core": "npm:^2.30.0"
+    "@vivliostyle/core": "npm:^2.30.4"
     i18next-ko: "npm:^3.0.1"
     knockout: "npm:^3.5.0"
-  checksum: 10c0/8926aec7446c7276b723f8775a91c0a337ab0e3fe62e935015881eabdb1198b72723bb7fbc24c64b492792b7cffffc7adbb4bfd4f1efa5cbbea2d9c9590dca94
+  checksum: 10c0/7686da37bc33b0b130585bed851b28dec0858439cdde1dec922462fba990c485d061d0baa61a87c1066e51b0e1e2a8bcbcbff9a32e5d05f63eda56a9ba35843b
   languageName: node
   linkType: hard
 
@@ -1919,18 +1919,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cheerio@npm:^1.0.0-rc.10":
-  version: 1.0.0-rc.12
-  resolution: "cheerio@npm:1.0.0-rc.12"
+"cheerio@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "cheerio@npm:1.0.0"
   dependencies:
     cheerio-select: "npm:^2.1.0"
     dom-serializer: "npm:^2.0.0"
     domhandler: "npm:^5.0.3"
-    domutils: "npm:^3.0.1"
-    htmlparser2: "npm:^8.0.1"
-    parse5: "npm:^7.0.0"
+    domutils: "npm:^3.1.0"
+    encoding-sniffer: "npm:^0.2.0"
+    htmlparser2: "npm:^9.1.0"
+    parse5: "npm:^7.1.2"
     parse5-htmlparser2-tree-adapter: "npm:^7.0.0"
-  checksum: 10c0/c85d2f2461e3f024345b78e0bb16ad8e41492356210470dd1e7d5a91391da9fcf6c0a7cb48a9ba8820330153f0cedb4d0a60c7af15d96ecdb3092299b9d9c0cc
+    parse5-parser-stream: "npm:^7.1.2"
+    undici: "npm:^6.19.5"
+    whatwg-mimetype: "npm:^4.0.0"
+  checksum: 10c0/d0e16925d9c36c879edfaef1c0244c866375a4c7b8d6ccd7ae0ad42da7d26263ea1a3c17b9a1aa5965918deeff2d40ac2e7223824f8e6eca972df3b81316a09f
   languageName: node
   linkType: hard
 
@@ -2275,7 +2279,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "daigirin-2024-2@workspace:."
   dependencies:
-    "@vivliostyle/cli": "npm:^8.9.1"
+    "@vivliostyle/cli": "npm:^8.14.1"
     npm-run-all2: "npm:^6.0.0"
     textlint: "npm:^14.0.0"
     textlint-filter-rule-comments: "npm:^1.2.2"
@@ -2509,7 +2513,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"domutils@npm:^3.0.1":
+"domutils@npm:^3.0.1, domutils@npm:^3.1.0":
   version: 3.1.0
   resolution: "domutils@npm:3.1.0"
   dependencies:
@@ -2555,6 +2559,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"encoding-sniffer@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "encoding-sniffer@npm:0.2.0"
+  dependencies:
+    iconv-lite: "npm:^0.6.3"
+    whatwg-encoding: "npm:^3.1.1"
+  checksum: 10c0/b312e0d67f339bec44e021e5210ee8ee90d7b8f9975eb2c79a36fd467eb07709e88dcf62ee20f62ee0d74a13874307d99557852a2de9b448f1e3fb991fc68257
+  languageName: node
+  linkType: hard
+
 "encoding@npm:^0.1.13":
   version: 0.1.13
   resolution: "encoding@npm:0.1.13"
@@ -2573,7 +2587,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"entities@npm:^4.2.0, entities@npm:^4.4.0":
+"entities@npm:^4.2.0, entities@npm:^4.4.0, entities@npm:^4.5.0":
   version: 4.5.0
   resolution: "entities@npm:4.5.0"
   checksum: 10c0/5b039739f7621f5d1ad996715e53d964035f75ad3b9a4d38c6b3804bb226e282ffeae2443624d8fdd9c47d8e926ae9ac009c54671243f0c3294c26af7cc85250
@@ -3585,15 +3599,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"htmlparser2@npm:^8.0.1":
-  version: 8.0.2
-  resolution: "htmlparser2@npm:8.0.2"
+"htmlparser2@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "htmlparser2@npm:9.1.0"
   dependencies:
     domelementtype: "npm:^2.3.0"
     domhandler: "npm:^5.0.3"
-    domutils: "npm:^3.0.1"
-    entities: "npm:^4.4.0"
-  checksum: 10c0/609cca85886d0bf2c9a5db8c6926a89f3764596877492e2caa7a25a789af4065bc6ee2cdc81807fe6b1d03a87bf8a373b5a754528a4cc05146b713c20575aab4
+    domutils: "npm:^3.1.0"
+    entities: "npm:^4.5.0"
+  checksum: 10c0/394f6323efc265bbc791d8c0d96bfe95984e0407565248521ab92e2dc7668e5ceeca7bc6ed18d408b9ee3b25032c5743368a4280d280332d782821d5d467ad8f
   languageName: node
   linkType: hard
 
@@ -3684,7 +3698,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2":
+"iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2, iconv-lite@npm:^0.6.3":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
   dependencies:
@@ -5691,6 +5705,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse5-parser-stream@npm:^7.1.2":
+  version: 7.1.2
+  resolution: "parse5-parser-stream@npm:7.1.2"
+  dependencies:
+    parse5: "npm:^7.0.0"
+  checksum: 10c0/e236c61000d38ecad369e725a48506b051cebad8abb00e6d4e8bff7aa85c183820fcb45db1559cc90955bdbbdbd665ea94c41259594e74566fff411478dc7fcb
+  languageName: node
+  linkType: hard
+
 "parse5@npm:^5.0.0":
   version: 5.1.1
   resolution: "parse5@npm:5.1.1"
@@ -5882,12 +5905,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.44.1":
-  version: 1.44.1
-  resolution: "playwright-core@npm:1.44.1"
+"playwright-core@npm:1.46.1":
+  version: 1.46.1
+  resolution: "playwright-core@npm:1.46.1"
   bin:
     playwright-core: cli.js
-  checksum: 10c0/6ffa3a04822b3df86d7f47a97e4f20318c0c50868ba4311820e6626ecadaab1424fbd0a3d01f0b4228adc0c781115e44b801742a4970b88739f804d82f142d68
+  checksum: 10c0/98e48e271caccaa6c54b3c591cbddbef36a679eef011b38e2af11fbaba0aab1f997b45f9207c4099468a0c79047a1e879bbd9e81bd880ae24501a0ee3c7a33c7
   languageName: node
   linkType: hard
 
@@ -7917,6 +7940,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici@npm:^6.19.5":
+  version: 6.19.8
+  resolution: "undici@npm:6.19.8"
+  checksum: 10c0/07fd8520bce7e34ea29c07ef0de27b734183042cdb4e2f1262cd1fb9b755a6b04ff2471040395dfb1770fb7786069a97c5178bcf706b80a34075994f46feb37c
+  languageName: node
+  linkType: hard
+
 "unherit@npm:^1.0.4":
   version: 1.1.3
   resolution: "unherit@npm:1.1.3"
@@ -8374,10 +8404,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"whatwg-encoding@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "whatwg-encoding@npm:3.1.1"
+  dependencies:
+    iconv-lite: "npm:0.6.3"
+  checksum: 10c0/273b5f441c2f7fda3368a496c3009edbaa5e43b71b09728f90425e7f487e5cef9eb2b846a31bd760dd8077739c26faf6b5ca43a5f24033172b003b72cf61a93e
+  languageName: node
+  linkType: hard
+
 "whatwg-mimetype@npm:^3.0.0":
   version: 3.0.0
   resolution: "whatwg-mimetype@npm:3.0.0"
   checksum: 10c0/323895a1cda29a5fb0b9ca82831d2c316309fede0365047c4c323073e3239067a304a09a1f4b123b9532641ab604203f33a1403b5ca6a62ef405bcd7a204080f
+  languageName: node
+  linkType: hard
+
+"whatwg-mimetype@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "whatwg-mimetype@npm:4.0.0"
+  checksum: 10c0/a773cdc8126b514d790bdae7052e8bf242970cebd84af62fb2f35a33411e78e981f6c0ab9ed1fe6ec5071b09d5340ac9178e05b52d35a9c4bcf558ba1b1551df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
fix #2 

セキュリティ問題でwsをアップデートするPRをかつて作りましたが、yarn の更新でlockファイルが大きく変わり、人力でコンフリクト解消は無理になった。wsを使っている @vivliostyle/cli を更新して、間接的に更新する。