### PR TITLE
コードハイライトが有効になるように修正

### DIFF
--- a/book/manuscripts/yusuga.md
+++ b/book/manuscripts/yusuga.md
@@ -1015,7 +1015,8 @@ struct OpenAPIRequestInjectionMiddleware: AsyncMiddleware {
 }
 ```
 
-<!-- textlint-disable -->`Sources/App/entrypoint.swift`<!-- textlint-enable --> の main メソッド内で OpenAPIRequestInjectionMiddleware を VaporTransport に追加します。
+<!-- textlint-disable -->
+`Sources/App/entrypoint.swift`<!-- textlint-enable --> の main メソッド内で OpenAPIRequestInjectionMiddleware を VaporTransport に追加します。
 
 
 ```diff


### PR DESCRIPTION
`<!-- textlint-disable -->` と ``` が連続しているとコードハイライトの開始として認識されていませんでした。

@yusuga 意図した表現になっているか確認をお願いしたいです。

| before | after |
| -- | -- |
<img width="498" alt="Screenshot 2024-10-14 at 10 14 32" src="https://github.com/user-attachments/assets/9484f6fd-85a5-49cd-a936-8ba17b55583b"> | <img width="503" alt="Screenshot 2024-10-14 at 10 12 36" src="https://github.com/user-attachments/assets/98f19851-a9b0-4bdc-86c2-1eb87b7b566b">